### PR TITLE
fix Deadlock when calling next after Exhaustion

### DIFF
--- a/prefetch_generator/__init__.py
+++ b/prefetch_generator/__init__.py
@@ -75,6 +75,7 @@ class BackgroundGenerator(threading.Thread):
         self.generator = generator
         self.daemon = True
         self.start()
+        self.exhausted = False
 
     def run(self):
         for item in self.generator:
@@ -82,10 +83,13 @@ class BackgroundGenerator(threading.Thread):
         self.queue.put(None)
 
     def next(self):
-        next_item = self.queue.get()
-        if next_item is None:
+        if self.exhausted:
             raise StopIteration
-        return next_item
+        else:
+            next_item = self.queue.get()
+            if next_item is None:
+                raise StopIteration
+            return next_item
 
     # Python 3 compatibility
     def __next__(self):


### PR DESCRIPTION
Hi,
verry helpfull Codesnippet/Libary!
just run in a little error:
when you call next(gen) or gen.__next__() after the generator is exhaustet an Deadlock is generated since the next function is waiting for the next Element in the Que, which will never come.
When using the Generator in a For in Loop this never happens, but when using it manually by calling next this can happen.
(which happend for me and took quite a time to find it since i ran in Docker without debugging...)
"normal" generators also throw the StopIteration error every time you call them after exhaustion, not just the first time.