### PR TITLE
add preprocess hook

### DIFF
--- a/prefetch_generator/__init__.py
+++ b/prefetch_generator/__init__.py
@@ -49,7 +49,7 @@ else:
 
 
 class BackgroundGenerator(threading.Thread):
-    def __init__(self, generator, max_prefetch=1):
+    def __init__(self, generator, max_prefetch=1, preprocess_func=None):
         """
 
         This function transforms generator into a background-thead generator.
@@ -73,12 +73,14 @@ class BackgroundGenerator(threading.Thread):
         threading.Thread.__init__(self)
         self.queue = Queue.Queue(max_prefetch)
         self.generator = generator
+        self.preprocess_func = preprocess_func
         self.daemon = True
         self.start()
         self.exhausted = False
 
     def run(self):
         for item in self.generator:
+            item = item if self.preprocess_func is None else self.preprocess_func(item)
             self.queue.put(item)
         self.queue.put(None)
 


### PR DESCRIPTION
When using tf.data.Dataset with pytorch or jax / flax, after receiving next, it is necessary to convert from tf Tensor to pytorch, jax / flax Tensor or transfer it to the target device. I propose an MR that sets the preprocess function to include this work in the prefetch.

usage

```python
def convert_tf_to_pytorch(sample):
    converted_sample = some_operation(sample)
    return converted_sample

def main():
    # ...
    dataset = create_some_tf_data_Dataset()
    dataset = BackgroundGenerator(dataset, preprocess_func=convert_tf_to_pytorch)

    for sample in dataset:
        # The sample has already been converted from TensorFlow to PyTorch in the background.
        train_step(sample)
```