### PR TITLE
Various fixes and improvements (See pull request for details)

### DIFF
--- a/example.ipynb
+++ b/example.ipynb
@@ -12,49 +12,49 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "\n",
-      "#based on http://stackoverflow.com/questions/7323664/python-generator-pre-fetch\n",
+      "Based on http://stackoverflow.com/questions/7323664/python-generator-pre-fetch\n",
       "\n",
-      "This is a single-function package that transforms arbitrary generator into a background-thead generator that prefetches several batches of data in a parallel background thead.\n",
+      "This is a single-function package that makes it possible to transform any generator into a `BackgroundGenerator` which computes any number of elements from the generator ahead, in a background thread.\n",
       "\n",
-      "This is useful if you have a computationally heavy process (CPU or GPU) that iteratively processes minibatches from the generator while the generator consumes some other resource (disk IO / loading from database / more CPU if you have unused cores). \n",
+      "It is quite lightweight, but not entirely weightless.\n",
       "\n",
-      "By default these two processes will constantly wait for one another to finish. If you make generator work in prefetch mode (see examples below), they will work in parallel, potentially saving you your GPU time.\n",
+      "The `BackgroundGenerator` is most useful when you have a GIL releasing task which might take a long time to complete (e.g. Disk I/O, Web Requests, pure C functions, GPU processing, ...), and another task which takes a similar amount of time, but is dependent on the results of the first task (e.g. Computationally intensive processing of data loaded from disk).\n",
       "\n",
-      "We personally use the prefetch generator when iterating minibatches of data for deep learning with tensorflow and theano ( lasagne, blocks, raw, etc.).\n",
+      "Normally these two tasks will constantly wait for one another to finish. If you make one of these tasks a `BackgroundGenerator` (see examples below), they will work in parallel, potentially saving up to 50% of execution time (definitely less in practice).\n",
       "\n",
-      "This package contains two objects\n",
-      " - BackgroundGenerator(any_other_generator[,max_prefetch = something])\n",
-      " - @background([max_prefetch=somethind]) decorator\n",
+      "We personally use the `BackgroundGenerator` when iterating over minibatches of data for deep learning with tensorflow and theano ( lasagne, blocks, raw, etc.).\n",
+      "\n",
+      "Quick usage example (ipython notebook) - https://github.com/justheuristic/prefetch_generator/blob/master/example.ipynb\n",
+      "\n",
+      "This package contains two objects:\n",
+      " - The Class     `BackgroundGenerator(generator [,max_prefetch=1])`\n",
+      " - The decorator `@prefetch([max_prefetch=1])`\n",
       "\n",
       "the usage is either\n",
       "\n",
-      "#for batch in BackgroundGenerator(my_minibatch_iterator):\n",
-      "#    doit()\n",
+      "#for item in BackgroundGenerator(my_generator):\n",
+      "#    do_stuff(item)\n",
       "\n",
       "or\n",
       "\n",
-      "#@background()\n",
-      "#def iterate_minibatches(some_param):\n",
+      "#@prefetch()\n",
+      "#def my_generator(some_param):\n",
       "#    while True:\n",
       "#        X = read_heavy_file()\n",
-      "#        X = do_helluva_math(X)\n",
-      "#        y = wget_from_pornhub()\n",
-      "#        do_pretty_much_anything()\n",
-      "#        yield X_batch, y_batch\n",
+      "#        y = wget_from_cornhub()\n",
+      "#        do_pretty_much_anything(some_param)\n",
+      "#        yield X, y\n",
       "\n",
       "\n",
-      "More details are written in the BackgroundGenerator doc\n",
-      "help(BackgroundGenerator)\n",
-      "\n",
+      "More details are written in the `BackgroundGenerator` doc:\n",
+      "See `help(BackgroundGenerator)`\n",
       "\n"
      ]
     }
@@ -69,9 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "###your super-mega data iterator\n",
@@ -96,9 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -135,9 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -193,9 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -232,23 +224,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [Root]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "Python [Root]"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     url="https://github.com/justheuristic/prefetch_generator",
 
     # Choose your license
-    license='MIT',
+    license='The Unlicense',
     packages=find_packages(),
 
     classifiers=[
@@ -33,7 +33,7 @@ setup(
         'Topic :: Scientific/Engineering',
 
         # Pick your license as you wish (should match "license" above)
-        "License :: OSI Approved :: MIT License",
+        'License :: OSI Approved :: The Unlicense (Unlicense)',
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
@@ -43,6 +43,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
 
     ],
 


### PR DESCRIPTION
Hi, I've been using a modified version of this code for some time now, and I though I should merge the improvements I made back into this Project.
One thing I didn't do is increment the version number in `setup.py`. Just a heads up for the maintainers should this pull request be accepted.
I hope these changes are in line with what the maintainers intended.
Here's a list of all the changes I made, and why I made them:


1. Improve docs for module, class, and decorator by giving them more structure, fixing typos, and rewriting parts with (hopefully) more accurate examples.

2. Improve imports by only importing exactly what is needed.

3. Add a `__all__` to specify which symbols to export, should the module be imported using the `from prefetch_generator import *` syntax.

4. Reduce the impact of the `preprocess_func=` argument introduced in [add preprocess hook #10](https://github.com/justheuristic/prefetch_generator/pull/10) by replacing the `run` function during `__init__`, instead of checking for `None` during every iteration of the generator.  
5. The `preprocess_func=` argument has also been marked as deprecated.  
`BackgroundGenerator(my_generator, 1, my_preprocessor)` is exactly the same as using  
`BackgroundGenerator((my_preprocessor(item) for item in my_generator), 1)`,  
or simply calling `my_preprocessor` before returning from `my_generator`, making the argument entirely redundant.  
I believe it is better to not add complexity such as this to the project.  


6. Actually make the fix introduced in [fix Deadlock when calling next after Exhaustion #6](https://github.com/justheuristic/prefetch_generator/pull/6) work. The pull request added a flag to check if the generator is exhausted, but never modified that flag.

7. Pass Exceptions happening in the background thread to the main thread and re-raise them there. Previously a Exception in the background thread would print a message, but leave the main thread stuck waiting on the queue, and without a proper stack trace for debugging.

8. The end of a generator is no longer signaled by `None` passed through the queue, but instead every element passed through the queue is a tuple of either the boolean `True` and the computed element, or the boolean `False` and an Exception. The Exception can be from an error while computing elements of the generator, or `StopIteration`, signalling that the end of the generator has been reached.

9. The `__next__` method for python 2/3 compatibility now simply points to the `next` method, instead of actually being implemented, reducing overhead.

10. The decorator is now a function, instead of a class (which I believe is cleaner), and uses `update_wrapper` from the `functools` library to preserve the signature and docs of the decorated function.

11. The decorator has also been renamed from `background` to `prefetch`, which I believe is more intuitive. The `background` name is still available as an alias in order to not break backwards compatibility.

12. Added python 3.9 and 3.10 to the list of compatible versions, and test that everything works in versions 2.7, 3.8, 3.9, and 3.10.

13. Switch to "The Unlicense" in `setup.py`, to be in line with the License of this Repository, last modified in [switch to unlicense #4](https://github.com/justheuristic/prefetch_generator/pull/4).  